### PR TITLE
Install ruby-augeas from RubyGems on Debian for Ruby >= 2.0.0

### DIFF
--- a/manifests/ssh/config.pp
+++ b/manifests/ssh/config.pp
@@ -55,7 +55,7 @@ define homes::ssh::config(
         package { 'ruby-augeas':
           ensure   => present,
           provider => 'gem',
-          install_options => "-v ${$ruby_augeas_version}"
+          install_options => [ { '-v' => $ruby_augeas_version } ]
         }
       } else {
         ensure_resource('package', 'libaugeas-ruby', { 'ensure' => 'installed' })


### PR DESCRIPTION
Ubuntu's PPAs don't include a ruby-augeas package for newer versions of Ruby. This patch installs ruby-augeas from RubyGems and the necessary dependencies.